### PR TITLE
Always Show Resumes Dropdown

### DIFF
--- a/about.html
+++ b/about.html
@@ -43,7 +43,11 @@
             <a class="nav-item nav-link" href="/">Home</a>
             <a class="nav-item nav-link active" href="about.html">About</a>
             <a class="nav-item nav-link" href="projects.html">Projects</a>
-            <div id="resume-nav-item-container"></div>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button"
+                    data-bs-toggle="dropdown" aria-expanded="false">Resumes</a>
+                <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+            </li>
             <a class="nav-item nav-link" href="contact.html">Contact</a>
         </div>
 
@@ -106,20 +110,6 @@
         </a>
 
     </footer>
-
-    <!-- Single Resume Link Template for Navbar. -->
-    <template id="singleResumeLinkTemplate">
-        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
-    </template>
-
-    <!-- Multiple Resumes Link Template for Navbar. -->
-    <template id="multipleResumesLinkTemplate">
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
-                aria-expanded="false">Resumes</a>
-            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
-        </li>
-    </template>
 
     <!-- Resume List Item Template for Navbar. -->
     <template id="resumeListItemTemplate">

--- a/about.html
+++ b/about.html
@@ -107,6 +107,27 @@
 
     </footer>
 
+    <!-- Single Resume Link Template for Navbar. -->
+    <template id="singleResumeLinkTemplate">
+        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
+    </template>
+
+    <!-- Multiple Resumes Link Template for Navbar. -->
+    <template id="multipleResumesLinkTemplate">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Resumes</a>
+            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+        </li>
+    </template>
+
+    <!-- Resume List Item Template for Navbar. -->
+    <template id="resumeListItemTemplate">
+        <li>
+            <a class="dropdown-item" id="resume-link" target="_blank" rel="noreferrer noopener"></a>
+        </li>
+    </template>
+
 </body>
 
 </html>

--- a/contact.html
+++ b/contact.html
@@ -93,6 +93,27 @@
 
     </footer>
 
+    <!-- Single Resume Link Template for Navbar. -->
+    <template id="singleResumeLinkTemplate">
+        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
+    </template>
+
+    <!-- Multiple Resumes Link Template for Navbar. -->
+    <template id="multipleResumesLinkTemplate">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Resumes</a>
+            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+        </li>
+    </template>
+
+    <!-- Resume List Item Template for Navbar. -->
+    <template id="resumeListItemTemplate">
+        <li>
+            <a class="dropdown-item" id="resume-link" target="_blank" rel="noreferrer noopener"></a>
+        </li>
+    </template>
+
 </body>
 
 </html>

--- a/contact.html
+++ b/contact.html
@@ -44,7 +44,11 @@
             <a class="nav-item nav-link" href="/">Home</a>
             <a class="nav-item nav-link" href="about.html">About</a>
             <a class="nav-item nav-link" href="projects.html">Projects</a>
-            <div id="resume-nav-item-container"></div>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button"
+                    data-bs-toggle="dropdown" aria-expanded="false">Resumes</a>
+                <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+            </li>
             <a class="nav-item nav-link active" href="contact.html">Contact</a>
         </div>
 
@@ -92,20 +96,6 @@
         </a>
 
     </footer>
-
-    <!-- Single Resume Link Template for Navbar. -->
-    <template id="singleResumeLinkTemplate">
-        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
-    </template>
-
-    <!-- Multiple Resumes Link Template for Navbar. -->
-    <template id="multipleResumesLinkTemplate">
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
-                aria-expanded="false">Resumes</a>
-            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
-        </li>
-    </template>
 
     <!-- Resume List Item Template for Navbar. -->
     <template id="resumeListItemTemplate">

--- a/index.html
+++ b/index.html
@@ -43,7 +43,11 @@
             <a class="nav-item nav-link active" href="/">Home</a>
             <a class="nav-item nav-link" href="about.html">About</a>
             <a class="nav-item nav-link" href="projects.html">Projects</a>
-            <div id="resume-nav-item-container"></div>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button"
+                    data-bs-toggle="dropdown" aria-expanded="false">Resumes</a>
+                <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+            </li>
             <a class="nav-item nav-link" href="contact.html">Contact</a>
         </div>
 
@@ -84,20 +88,6 @@
         </a>
 
     </footer>
-
-    <!-- Single Resume Link Template for Navbar. -->
-    <template id="singleResumeLinkTemplate">
-        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
-    </template>
-
-    <!-- Multiple Resumes Link Template for Navbar. -->
-    <template id="multipleResumesLinkTemplate">
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
-                aria-expanded="false">Resumes</a>
-            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
-        </li>
-    </template>
 
     <!-- Resume List Item Template for Navbar. -->
     <template id="resumeListItemTemplate">

--- a/index.html
+++ b/index.html
@@ -85,6 +85,27 @@
 
     </footer>
 
+    <!-- Single Resume Link Template for Navbar. -->
+    <template id="singleResumeLinkTemplate">
+        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
+    </template>
+
+    <!-- Multiple Resumes Link Template for Navbar. -->
+    <template id="multipleResumesLinkTemplate">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Resumes</a>
+            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+        </li>
+    </template>
+
+    <!-- Resume List Item Template for Navbar. -->
+    <template id="resumeListItemTemplate">
+        <li>
+            <a class="dropdown-item" id="resume-link" target="_blank" rel="noreferrer noopener"></a>
+        </li>
+    </template>
+
 </body>
 
 </html>

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,31 +1,4 @@
 /**
- * Renders resume navigation links into the resume nav item container.
- * - If there is only one resume, it creates a single "Resume" link.
- * - If there are multiple resumes, it creates a dropdown menu allowing users to select one.
- *
- * @param {Object[]} resumes - An array of resume objects to display.
- * @param {string} resumes[].name - The display name of the resume.
- * @param {string} resumes[].url - The URL pointing to the resume PDF.
- */
-function setupResumeNavItemContainer(resumes) {
-
-    const resumeNavItemContainer = document.getElementById("resume-nav-item-container");
-
-    if (resumes.length > 1) {
-        const template = document.getElementById("multipleResumesLinkTemplate");
-        const outerListItem = template.content.cloneNode(true).querySelector("li");
-        resumeNavItemContainer.appendChild(outerListItem);
-        const resumeDropdownMenu = outerListItem.querySelector("#resume-dropdown-menu");
-        resumes.forEach(resume => { addItemToResumeDropdownMenu(resumeDropdownMenu, resume) });
-    } else { // resumes.length == 1
-        const template = document.getElementById("singleResumeLinkTemplate");
-        const resumeLink = template.content.cloneNode(true).querySelector("a");
-        resumeLink.setAttribute("href", resumes[0].url);
-        resumeNavItemContainer.appendChild(resumeLink);
-    }
-}
-
-/**
  * Appends a single resume link as a dropdown menu item within the resume dropdown.
  *
  * @param {HTMLUListElement} resumeDropdownMenu - The `<ul>` element where the dropdown items will be added.
@@ -45,11 +18,31 @@ function addItemToResumeDropdownMenu(resumeDropdownMenu, resume) {
 /**
  * Initializes the resume navigation on page load by fetching resume data from a remote database.
  */
-document.addEventListener("DOMContentLoaded", () => {
-    fetch("https://david-read-portfolio-default-rtdb.firebaseio.com/resumes.json")
-        .then(response => response.json())
-        .then(resumes => { setupResumeNavItemContainer(resumes) })
-        .catch(error => {
-            console.error("Failed to fetch resumes:", error);
+// document.addEventListener("DOMContentLoaded", () => {
+//     fetch("https://david-read-portfolio-default-rtdb.firebaseio.com/resumes.json")
+//         .then(response => response.json())
+//         .then(resumes => {
+//             const resumeDropdownMenu = document.querySelector("#resume-dropdown-menu");
+//             resumes.forEach(resume => { addItemToResumeDropdownMenu(resumeDropdownMenu, resume) });
+//         })
+//         .catch(error => {
+//             console.error("Failed to fetch resumes:", error);
+//         });
+// });
+
+document.addEventListener("DOMContentLoaded", async () => {
+    // Artificial delay to simulate load time
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    try {
+        const response = await fetch("https://david-read-portfolio-default-rtdb.firebaseio.com/resumes.json");
+        const resumes = await response.json();
+
+        const resumeDropdownMenu = document.querySelector("#resume-dropdown-menu");
+        resumes.forEach(resume => {
+            addItemToResumeDropdownMenu(resumeDropdownMenu, resume);
         });
+    } catch (error) {
+        console.error("Failed to fetch resumes:", error);
+    }
 });

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,83 +1,54 @@
 /**
- * Sets up the content within the resume nav item container. If only one resume is given, will display a
- * single Resume link. If more than one resume is given, will display a dropdown where a specific resume
- * may be selected.
- * 
- * @param {Object[]} resumes - The resumes to display.
+ * Renders resume navigation links into the resume nav item container.
+ * - If there is only one resume, it creates a single "Resume" link.
+ * - If there are multiple resumes, it creates a dropdown menu allowing users to select one.
+ *
+ * @param {Object[]} resumes - An array of resume objects to display.
+ * @param {string} resumes[].name - The display name of the resume.
+ * @param {string} resumes[].url - The URL pointing to the resume PDF.
  */
 function setupResumeNavItemContainer(resumes) {
 
-    var resumeNavItemContainer = document.getElementById("resume-nav-item-container");
+    const resumeNavItemContainer = document.getElementById("resume-nav-item-container");
 
     if (resumes.length > 1) {
-        // Setup outer li tag.
-        var outerListItem = document.createElement("li");
-        outerListItem.setAttribute("class", "nav-item dropdown");
-
+        const template = document.getElementById("multipleResumesLinkTemplate");
+        const outerListItem = template.content.cloneNode(true).querySelector("li");
         resumeNavItemContainer.appendChild(outerListItem);
-
-        // Setup resume button.
-        var resumesLink = document.createElement("a");
-        resumesLink.setAttribute("class", "nav-link dropdown-toggle");
-        resumesLink.setAttribute("href", "#");
-        resumesLink.setAttribute("id", "resume-dropdown");
-        resumesLink.setAttribute("role", "button");
-        resumesLink.setAttribute("data-bs-toggle", "dropdown");
-        resumesLink.setAttribute("aria-expanded", "false");
-        resumesLink.textContent = "Resumes";
-
-        outerListItem.appendChild(resumesLink);
-
-        // Setup ul tag.
-        var resumeDropdownMenu = document.createElement("ul");
-        resumeDropdownMenu.setAttribute("class", "dropdown-menu");
-        resumeDropdownMenu.setAttribute("id", "resume-dropdown-menu");
-        resumeDropdownMenu.setAttribute("aria-labelledby", "resume-dropdown");
-
-        outerListItem.appendChild(resumeDropdownMenu);
-
-        // Add an item in the resume dropdown menu for each resume in the resumes array.
-        for (var i = 0; i < resumes.length; i++) {
-            addItemToResumeDropdownMenu(resumeDropdownMenu, resumes[i]);
-        }
+        const resumeDropdownMenu = outerListItem.querySelector("#resume-dropdown-menu");
+        resumes.forEach(resume => { addItemToResumeDropdownMenu(resumeDropdownMenu, resume) });
     } else { // resumes.length == 1
-        var resumeLink = document.createElement("a");
-        resumeLink.setAttribute("class", "nav-item nav-link");
+        const template = document.getElementById("singleResumeLinkTemplate");
+        const resumeLink = template.content.cloneNode(true).querySelector("a");
         resumeLink.setAttribute("href", resumes[0].url);
-        resumeLink.setAttribute("target", "_blank");
-        resumeLink.setAttribute("rel", "noreferrer noopener");
-        resumeLink.textContent = "Resume";
-
         resumeNavItemContainer.appendChild(resumeLink);
     }
 }
 
 /**
- * Adds a dropdown item representing the passed resume object to the resume dropdown menu.
- * 
- * @param {HTMLUListElement} dropdownMenu - A reference to the resume dropdown menu.
- * @param {Object} resume - The resume object to add.
+ * Appends a single resume link as a dropdown menu item within the resume dropdown.
+ *
+ * @param {HTMLUListElement} resumeDropdownMenu - The `<ul>` element where the dropdown items will be added.
+ * @param {Object} resume - The resume object to represent.
+ * @param {string} resume.name - The label to display for this resume in the dropdown.
+ * @param {string} resume.url - The URL to link to when the dropdown item is clicked.
  */
-function addItemToResumeDropdownMenu(dropdownMenu, resume) {
-    var htmlLiElement = document.createElement("li");
-
-    var htmlAElement = document.createElement("a");
-    htmlAElement.setAttribute("class", "dropdown-item");
-    htmlAElement.setAttribute("href", resume.url);
-    htmlAElement.setAttribute("target", "_blank");
-    htmlAElement.setAttribute("rel", "noreferrer noopener");
-    htmlAElement.textContent = resume.name;
-
-    htmlLiElement.appendChild(htmlAElement);
-    dropdownMenu.appendChild(htmlLiElement);
+function addItemToResumeDropdownMenu(resumeDropdownMenu, resume) {
+    const template = document.getElementById("resumeListItemTemplate");
+    const listItem = template.content.cloneNode(true).querySelector("li");
+    const link = listItem.querySelector("#resume-link");
+    link.setAttribute("href", resume.url);
+    link.textContent = resume.name;
+    resumeDropdownMenu.appendChild(listItem);
 }
 
+/**
+ * Initializes the resume navigation on page load by fetching resume data from a remote database.
+ */
 document.addEventListener("DOMContentLoaded", () => {
     fetch("https://david-read-portfolio-default-rtdb.firebaseio.com/resumes.json")
         .then(response => response.json())
-        .then(resumes => {
-            setupResumeNavItemContainer(resumes);
-        })
+        .then(resumes => { setupResumeNavItemContainer(resumes) })
         .catch(error => {
             console.error("Failed to fetch resumes:", error);
         });

--- a/projects.html
+++ b/projects.html
@@ -202,6 +202,27 @@
         <a class="btn btn-primary" target="_blank" rel="noopener noreferrer"></a>
     </template>
 
+    <!-- Single Resume Link Template for Navbar. -->
+    <template id="singleResumeLinkTemplate">
+        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
+    </template>
+
+    <!-- Multiple Resumes Link Template for Navbar. -->
+    <template id="multipleResumesLinkTemplate">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Resumes</a>
+            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+        </li>
+    </template>
+
+    <!-- Resume List Item Template for Navbar. -->
+    <template id="resumeListItemTemplate">
+        <li>
+            <a class="dropdown-item" id="resume-link" target="_blank" rel="noreferrer noopener"></a>
+        </li>
+    </template>
+
 </body>
 
 </html>

--- a/projects.html
+++ b/projects.html
@@ -44,7 +44,11 @@
             <a class="nav-item nav-link" href="/">Home</a>
             <a class="nav-item nav-link" href="about.html">About</a>
             <a class="nav-item nav-link active" href="projects.html">Projects</a>
-            <div id="resume-nav-item-container"></div>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button"
+                    data-bs-toggle="dropdown" aria-expanded="false">Resumes</a>
+                <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
+            </li>
             <a class="nav-item nav-link" href="contact.html">Contact</a>
         </div>
 
@@ -200,20 +204,6 @@
     <!-- Modal footer button template. -->
     <template id="modalButtonTemplate">
         <a class="btn btn-primary" target="_blank" rel="noopener noreferrer"></a>
-    </template>
-
-    <!-- Single Resume Link Template for Navbar. -->
-    <template id="singleResumeLinkTemplate">
-        <a class="nav-item nav-link" target="_blank" rel="noreferrer noopener">Resume</a>
-    </template>
-
-    <!-- Multiple Resumes Link Template for Navbar. -->
-    <template id="multipleResumesLinkTemplate">
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="resume-dropdown" href="#" role="button" data-bs-toggle="dropdown"
-                aria-expanded="false">Resumes</a>
-            <ul class="dropdown-menu" id="resume-dropdown-menu" aria-labelledby="resume-dropdown"></ul>
-        </li>
     </template>
 
     <!-- Resume List Item Template for Navbar. -->


### PR DESCRIPTION
- Use templates to simplify programmatic object creation in navbar.js.
- Always show Resumes Dropdown in Navbar, even in single resume scenario. Rationale is that I would need to basically hide the entire screen to wait on the resume service call to conclude. This would tightly couple the resume logic with the rest of the site. Further, switching pages would cause the entire page to disappear, since the resume service call happens each page switch.